### PR TITLE
Lint Front Matter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,29 @@ jobs:
             with:
                 eclint_args: |
                     -exclude=css/*
+
+    lint_front_matter:
+        name: Lint Front Matter
+        runs-on: ubuntu-latest
+
+        steps:
+        -
+            name: Checkout repository
+            uses: actions/checkout@v3
+        -
+            name: Cache pip
+            uses: actions/cache@v3
+            with:
+                path: '~/.cache/pip'
+                key: '${{ runner.os }}-pip-yamllint'
+        -
+            name: Install yamllint
+            run: pip install --user yamllint
+        -
+            name: Remove document contents
+            run: |
+                git ls-files -z -- 'src/**.md' | xargs -0 -n 1 -- sed -i -e 'N;P;/---\n$/Q;D'
+        -
+            name: Check Front Matter
+            run: |
+                git ls-files -z -- 'src/**.md' | xargs -0 -n 1 -- python -m yamllint

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -14,7 +14,7 @@ rules:
     indentation:
         spaces: 4
         indent-sequences: false
-    line-length: false
+    line-length: "disable"
     quoted-strings:
         quote-type: "double"
         required: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,20 @@
+---
+extends: "default"
+
+rules:
+    document-start:
+        present: true
+    braces:
+        forbid: true
+    brackets:
+        forbid: false
+    empty-values:
+        forbid-in-block-mappings: true
+        forbid-in-flow-mappings: true
+    indentation:
+        spaces: 4
+        indent-sequences: false
+    line-length: false
+    quoted-strings:
+        quote-type: "double"
+        required: true


### PR DESCRIPTION
1. Remove the contents from Markdown files
2. Run `yamllint` on the rest of the document, thus the Front Matter
