### PR TITLE
Reorder HTML elements in head

### DIFF
--- a/src/_includes/layout/base.html
+++ b/src/_includes/layout/base.html
@@ -4,13 +4,12 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
     <head>
-        <script src="/js/theme-detection.js?{{ assetHash }}"></script>
-        {% include "partial/preload.html" %}
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-        <link rel="alternate" type="application/rss+xml" href="{{ site.url }}/feed.xml" />
         {% include "partial/meta.html" %}
+        <link rel="alternate" type="application/rss+xml" href="{{ site.url }}/feed.xml" />
+        {% include "partial/preload.html" %}
 
         {% set css %}
             {% include "../../css/main.css" %}
@@ -21,6 +20,7 @@
         </style>
 
         {% block styles %}{% endblock %}
+        <script src="/js/theme-detection.js?{{ assetHash }}"></script>
     </head>
     <body>
         <a class="btn btn--primary skip-link" href="#content">Skip to content</a>


### PR DESCRIPTION
The browser badly needs **charset, viewport, http-equiv and title**, no matter what.

Absolutely no rendering is done in the `<head>`, so the """late""" theme detection script causes no FOUC.
(`<head>` has zero content)