### PR TITLE
Remove blank line from highlighted-text

### DIFF
--- a/src/_includes/partial/highlighted-text.html
+++ b/src/_includes/partial/highlighted-text.html
@@ -1,4 +1,3 @@
-
 {% if highlighted.title %}
     <div class="highlighted-text">
         <div class="container">


### PR DESCRIPTION
There was _one more_ blank line.
Added in https://github.com/conedevelopment/cone-site/commit/b1aaf7537d00218a92a5986eba5e9e20d472c7fb#diff-d9d62ae190b51f1479dd5e64351e832309956c343ec0b3f4636d1f7486c8ab76


Discovered by [the Integrity workflow](https://github.com/szepeviktor/byte-level-care/blob/master/.github/workflows/reusable-integrity.yml).
